### PR TITLE
feature/Update default encoding to support foreign characters

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ var gen = require('generate-object-property')
 
 var CsvWriteStream = function(opts) {
   if (!opts) opts = {}
-  stream.Transform.call(this, {objectMode:true, highWaterMark:16})
+  stream.Transform.call(this, {objectMode:true, highWaterMark:16, defaultEncoding: opts.defaultEncoding || 'utf8'});
 
   this.sendHeaders = opts.sendHeaders !== false
   this.headers = opts.headers || null


### PR DESCRIPTION
This is for:
https://highground.atlassian.net/browse/HG-4559
https://highground.atlassian.net/browse/HG-5132

Update so that we can set default encoding to utf-16 to support foreign characters in csv reports.